### PR TITLE
Reconnect on connection lost

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1542,6 +1542,7 @@ dependencies = [
  "jsonrpsee-core",
  "jsonrpsee-http-client",
  "jsonrpsee-types",
+ "jsonrpsee-ws-client",
 ]
 
 [[package]]
@@ -1619,6 +1620,18 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tracing",
+]
+
+[[package]]
+name = "jsonrpsee-ws-client"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b83daeecfc6517cfe210df24e570fb06213533dfb990318fae781f4c7119dd9"
+dependencies = [
+ "http",
+ "jsonrpsee-client-transport",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
 ]
 
 [[package]]
@@ -2863,6 +2876,7 @@ dependencies = [
  "clap",
  "color-eyre",
  "futures",
+ "jsonrpsee",
  "lettre",
  "parity-scale-codec",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ array-bytes        = { version = "6.1" }
 clap               = { version = "4.3", features = ["derive"] }
 color-eyre         = { version = "0.6" }
 futures            = { version = "0.3" }
+jsonrpsee          = { version = "0.16", features = ["async-client", "jsonrpsee-client-transport", "ws-client"] }
 lettre             = { version = "0.10" }
 parity-scale-codec = { version = "3.6" }
 regex              = { version = "1.8" }

--- a/src/hunter.rs
+++ b/src/hunter.rs
@@ -74,8 +74,8 @@ impl Hunter {
 			},
 			notification: Notification { mail: None, webhooks: Vec::new() },
 		};
-		let client = Self::ws_connect(&configuration.node_endpoint).await?;
-		let node = OnlineClient::from_rpc_client(client.clone()).await?;
+		let client = Self::ws_connect(&configuration.node_endpoint).await.unwrap();
+		let node = OnlineClient::from_rpc_client(client.clone()).await.unwrap();
 
 		Self {
 			configuration,

--- a/src/hunter.rs
+++ b/src/hunter.rs
@@ -18,9 +18,13 @@ pub use tx::*;
 pub use crate::prelude::*;
 
 // std
-use std::mem;
+use std::{mem, sync::Arc, thread, time::Duration};
 // crates.io
 use futures::StreamExt;
+use jsonrpsee::{
+	async_client::{Client as WsClient, ClientBuilder as WsClientBuilder},
+	client_transport::ws::WsTransportClientBuilder,
+};
 use reqwest::Client;
 use scale_value::ValueDef;
 #[cfg(feature = "node-test")] use sp_core::{sr25519::Pair, Pair as _};
@@ -37,6 +41,7 @@ type Block =
 pub struct Hunter {
 	pub configuration: Configuration,
 	pub http: Client,
+	_ws_connection: Arc<WsClient>,
 	pub node: OnlineClient<PolkadotConfig>,
 	pub auction: Option<AuctionDetail>,
 	pub auction_ending_period: BlockNumber,
@@ -69,11 +74,13 @@ impl Hunter {
 			},
 			notification: Notification { mail: None, webhooks: Vec::new() },
 		};
-		let node = OnlineClient::from_url(&configuration.node_endpoint).await.unwrap();
+		let client = Self::ws_connect(&configuration.node_endpoint).await?;
+		let node = OnlineClient::from_rpc_client(client.clone()).await?;
 
 		Self {
 			configuration,
 			http: util::http_json_client(),
+			_ws_connection: client,
 			node,
 			auction: None,
 			auction_ending_period: 0,
@@ -127,6 +134,31 @@ impl Hunter {
 			self.update(&block_hash).await?;
 			self.hunt(block_height, block_hash, &mut has_bid).await?;
 		}
+	}
+
+	pub fn ws_is_connected(&self) -> bool {
+		self._ws_connection.is_connected()
+	}
+
+	pub async fn ws_reconnect(&mut self, tried: &mut bool) -> Result<()> {
+		if *tried {
+			thread::sleep(Duration::from_secs(5));
+		}
+
+		*tried = true;
+
+		let client = Self::ws_connect(&self.configuration.node_endpoint).await?;
+
+		self.node = OnlineClient::from_rpc_client(client.clone()).await?;
+		self._ws_connection = client;
+
+		Ok(())
+	}
+
+	async fn ws_connect(uri: &str) -> Result<Arc<WsClient>> {
+		let (tx, rx) = WsTransportClientBuilder::default().build(uri.parse()?).await?;
+
+		Ok(Arc::new(WsClientBuilder::default().build_with_tokio(tx, rx)))
 	}
 
 	async fn initialize(&mut self) -> Result<BlockStream> {

--- a/src/hunter/configuration.rs
+++ b/src/hunter/configuration.rs
@@ -238,11 +238,13 @@ impl Token {
 
 impl Hunter {
 	pub async fn from_configuration(configuration: Configuration) -> Result<Self> {
-		let node = OnlineClient::from_url(&configuration.node_endpoint).await?;
+		let client = Self::ws_connect(&configuration.node_endpoint).await?;
+		let node = OnlineClient::from_rpc_client(client.clone()).await?;
 
 		Ok(Self {
 			configuration,
 			http: util::http_json_client(),
+			_ws_connection: client,
 			node,
 			auction: None,
 			auction_ending_period: 0,


### PR DESCRIPTION
```rs
2023-06-28T17:21:56.269530Z  INFO slothunter::hunter: ############################################################
2023-06-28T17:21:56.269976Z  INFO slothunter::hunter: node endpoint(ws://127.0.0.1:9944)
2023-06-28T17:21:56.270349Z  INFO slothunter::hunter: graphql endpoint(http://127.0.0.1:3000/graphql)
2023-06-28T17:21:56.270368Z  INFO slothunter::hunter: bid
2023-06-28T17:21:56.270383Z  INFO slothunter::hunter:   hunting a slot for parachain(2000)
2023-06-28T17:21:56.270396Z  INFO slothunter::hunter:   watch-only(true)
2023-06-28T17:21:56.270401Z  INFO slothunter::hunter: notification
2023-06-28T17:21:56.270403Z  INFO slothunter::hunter:   webhooks
2023-06-28T17:21:56.270406Z  INFO slothunter::hunter: ############################################################
2023-06-28T17:22:00.005807Z  INFO slothunter::hunter: block(#107, 0xf7fb7202976c109a5caa170ad6493f84657327a742f004886f7a52d40db99612)
2023-06-28T17:22:06.006089Z  INFO slothunter::hunter: block(#108, 0x99d90bbd427dd6e555ea8a38eb77d43b955323ce2286aa3e061f17e9513b5ad6)
2023-06-28T17:22:12.007347Z  INFO slothunter::hunter: block(#109, 0xee6b8ebbac9d768134636541a19c54cd490d4358b195d9eef43651812d5cbd06)
2023-06-28T17:22:13.471701Z ERROR jsonrpsee_core::client::async_client: [backend]: Networking or low-level protocol error: WebSocket connection error: connection closed
2023-06-28T17:22:13.471858Z ERROR slothunter: websocket connection was lost due to error(failed to get the next block)
2023-06-28T17:22:13.472232Z ERROR slothunter: failed to establish a websocket connection due to error(Error in the WebSocket handshake: i/o error: Connection reset by peer (os error 104))
2023-06-28T17:22:18.472766Z ERROR slothunter: failed to establish a websocket connection due to error(Error when opening the TCP socket: Connection refused (os error 111))
2023-06-28T17:22:23.473292Z ERROR slothunter: failed to establish a websocket connection due to error(Error when opening the TCP socket: Connection refused (os error 111))
2023-06-28T17:22:28.473829Z ERROR slothunter: failed to establish a websocket connection due to error(Error in the WebSocket handshake: i/o error: Connection reset by peer (os error 104))
2023-06-28T17:22:33.492343Z  INFO slothunter: websocket connection has been reestablished
2023-06-28T17:22:33.492783Z  INFO slothunter::hunter: ############################################################
2023-06-28T17:22:33.493195Z  INFO slothunter::hunter: node endpoint(ws://127.0.0.1:9944)
2023-06-28T17:22:33.493524Z  INFO slothunter::hunter: graphql endpoint(http://127.0.0.1:3000/graphql)
2023-06-28T17:22:33.493541Z  INFO slothunter::hunter: bid
2023-06-28T17:22:33.493553Z  INFO slothunter::hunter:   hunting a slot for parachain(2000)
2023-06-28T17:22:33.493680Z  INFO slothunter::hunter:   watch-only(true)
2023-06-28T17:22:33.493697Z  INFO slothunter::hunter: notification
2023-06-28T17:22:33.493719Z  INFO slothunter::hunter:   webhooks
2023-06-28T17:22:33.493724Z  INFO slothunter::hunter: ############################################################
2023-06-28T17:22:38.505951Z  INFO slothunter::hunter: block(#1, 0xe75845e89daf4cd85138ae445583e33f23f6218c6cfe83bd3988ea82d7151555)
2023-06-28T17:22:42.004485Z  INFO slothunter::hunter: block(#2, 0x8674d0f60e1804ffbb22c4c9d8cfd85729d94ab305484100a169f544a03f9196)
```